### PR TITLE
fix: use subprocess instead of os.system in extract_sound_samples.py

### DIFF
--- a/scripts/sound/extract_sound_samples.py
+++ b/scripts/sound/extract_sound_samples.py
@@ -5,4 +5,4 @@ for filename in os.listdir(directory):
     if filename.endswith('.bin'):
         filepath = directory + "/" + filename
         print('Extracting', filepath)
-        os.system('./tools/aif2pcm/aif2pcm ' + filepath)
+        __import__('subprocess').run(['./tools/aif2pcm/aif2pcm', filepath], check=True)


### PR DESCRIPTION
## Summary
Fix high severity security issue in `scripts/sound/extract_sound_samples.py`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `scripts/sound/extract_sound_samples.py:8` |

**Description**: The script constructs a shell command by directly concatenating the filepath variable into an os.system() call without any sanitization or validation. When the script iterates over files in a directory (e.g., via os.listdir or glob), an attacker can place a file with a maliciously crafted name containing shell metacharacters in the scanned directory to achieve arbitrary command execution with the privileges of the running process.

## Changes
- `scripts/sound/extract_sound_samples.py`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
